### PR TITLE
Fix Out-of-bounds Write in saveToMemory

### DIFF
--- a/arduino/codecard/memory.h
+++ b/arduino/codecard/memory.h
@@ -44,7 +44,7 @@ String getFromMemory(String key) {
 
 void saveToMemory(int addr, String val) {
   char arrayToStore[100];
-  val.toCharArray(arrayToStore, val.length()+1) ;
+  val.toCharArray(arrayToStore, 100) ;
   EEPROM.put(addr*maxValue, arrayToStore);
   EEPROM.commit();
 }


### PR DESCRIPTION
`saveToMemory()` is converting the given string `val` into a char array, but limited the copy to the size of the string instead of the array size.  
Inserting a string that is too large can override the stack and allow remote execution.